### PR TITLE
Add interactive route planner notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# traffic_lights_route
-Find the way for the best bicycle path with the least amount of traffic lights
+# Traffic Lights Route
+
+This repository contains a simple Jupyter notebook that plans routes using open data and visualises traffic lights along the way. It relies entirely on OpenStreetMap services so that everything can be run without proprietary map providers.
+
+## Features
+
+- Enter start and end addresses in a notebook interface.
+- Geocoding is performed with [OpenStreetMap Nominatim](https://nominatim.openstreetmap.org/).
+- Routing is retrieved from the public [OSRM](http://project-osrm.org/) API.
+- Traffic lights are loaded from a local GPX or GeoJSON file and displayed on the map.
+
+## Usage
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Add your traffic light file to the `data` folder and name it `traffic_lights.geojson` or `traffic_lights.gpx`.
+
+3. Launch Jupyter and open the notebook:
+
+   ```bash
+   jupyter notebook notebooks/traffic_lights_route.ipynb
+   ```
+
+4. Type the start and destination addresses in the provided boxes and click **Show Route** to display the map with the route and traffic light markers.
+
+An example GeoJSON file is provided in `data/traffic_lights_sample.geojson` for testing.

--- a/data/traffic_lights_sample.geojson
+++ b/data/traffic_lights_sample.geojson
@@ -1,0 +1,10 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"name": "Sample Traffic Light"},
+      "geometry": {"type": "Point", "coordinates": [4.899431, 52.379189]}
+    }
+  ]
+}

--- a/notebooks/traffic_lights_route.ipynb
+++ b/notebooks/traffic_lights_route.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Traffic Lights Route Planner\n",
+    "\n",
+    "Use this notebook to plan a route and visualize traffic lights along the way. Enter start and end addresses below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import requests\n",
+    "from pathlib import Path\n",
+    "import folium\n",
+    "from geopy.geocoders import Nominatim\n",
+    "import gpxpy\n",
+    "from ipywidgets import Text, Button, VBox, Output\n",
+    "from IPython.display import display\n",
+    "\n",
+    "TRAFFIC_LIGHTS_FILE = Path('data/traffic_lights.geojson')\n",
+    "\n",
+    "geolocator = Nominatim(user_agent='traffic_lights_route')\n",
+    "\n",
+    "def geocode(address: str):\n",
+    "    location = geolocator.geocode(address)\n",
+    "    if not location:\n",
+    "        raise ValueError(f'Could not geocode address: {address}')\n",
+    "    return (location.latitude, location.longitude)\n",
+    "\n",
+    "def get_route(start, end):\n",
+    "    url = f\"https://router.project-osrm.org/route/v1/driving/{start[1]},{start[0]};{end[1]},{end[0]}?overview=full&geometries=geojson\"\n",
+    "    r = requests.get(url)\n",
+    "    r.raise_for_status()\n",
+    "    data = r.json()\n",
+    "    coords = data['routes'][0]['geometry']['coordinates']\n",
+    "    return [(lat, lon) for lon, lat in coords]\n",
+    "\n",
+    "def load_traffic_lights(path=TRAFFIC_LIGHTS_FILE):\n",
+    "    path = Path(path)\n",
+    "    if not path.exists():\n",
+    "        return []\n",
+    "    lights = []\n",
+    "    if path.suffix.lower() in {'.geojson', '.json'}:\n",
+    "        data = json.loads(path.read_text())\n",
+    "        for feature in data.get('features', []):\n",
+    "            lon, lat = feature['geometry']['coordinates']\n",
+    "            name = feature['properties'].get('name', 'Traffic Light')\n",
+    "            lights.append((lat, lon, name))\n",
+    "    elif path.suffix.lower() == '.gpx':\n",
+    "        with path.open() as f:\n",
+    "            gpx = gpxpy.parse(f)\n",
+    "        for wp in gpx.waypoints:\n",
+    "            lights.append((wp.latitude, wp.longitude, wp.name or 'Traffic Light'))\n",
+    "    else:\n",
+    "        raise ValueError('Unsupported file type')\n",
+    "    return lights\n",
+    "\n",
+    "start_box = Text(description='Start:')\n",
+    "end_box = Text(description='End:')\n",
+    "button = Button(description='Show Route')\n",
+    "output = Output()\n",
+    "\n",
+    "def on_click(_):\n",
+    "    output.clear_output()\n",
+    "    with output:\n",
+    "        start = geocode(start_box.value)\n",
+    "        end = geocode(end_box.value)\n",
+    "        route = get_route(start, end)\n",
+    "        m = folium.Map(location=start, zoom_start=13)\n",
+    "        folium.PolyLine(route, color='blue', weight=5).add_to(m)\n",
+    "        for lat, lon, name in load_traffic_lights():\n",
+    "            folium.Marker((lat, lon), popup=name, icon=folium.Icon(color='red', icon='traffic-light')).add_to(m)\n",
+    "        display(m)\n",
+    "\n",
+    "button.on_click(on_click)\n",
+    "\n",
+    "VBox([start_box, end_box, button, output])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+folium
+geopy
+gpxpy
+ipywidgets
+requests


### PR DESCRIPTION
## Summary
- Create Jupyter notebook that geocodes start and end addresses, fetches routes from OSRM, and overlays traffic light markers from a local file
- Provide sample traffic light GeoJSON data and dependency list
- Document usage in updated README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c8ea14750832b97220c39354c5143